### PR TITLE
add stats tracking to proxy middleware

### DIFF
--- a/rotating_proxies/middlewares.py
+++ b/rotating_proxies/middlewares.py
@@ -73,7 +73,6 @@ class RotatingProxyMiddleware(object):
         self.reanimate_interval = 5
         self.stop_if_no_proxies = stop_if_no_proxies
         self.max_proxies_to_try = max_proxies_to_try
-        self.crawler = crawler
         self.stats = crawler.stats
 
     @classmethod
@@ -159,9 +158,9 @@ class RotatingProxyMiddleware(object):
         proxy = self.proxies.get_proxy(request.meta.get('proxy', None))
         if not (proxy and request.meta.get('_rotating_proxy')):
             return
-        self.stats.set_value('proxies/unchecked', len(self.proxies.unchecked) - len(self.proxies.reanimated))
+        self.stats.set_value('proxies/unchecked', len(self.proxies.unchecked))
         self.stats.set_value('proxies/reanimated', len(self.proxies.reanimated))
-        self.stats.set_value('proxies/mean_backoff', int(self.proxies.mean_backoff_time))
+        self.stats.set_value('proxies/mean_backoff', self.proxies.mean_backoff_time)
         ban = request.meta.get('_ban', None)
         if ban is True:
             self.proxies.mark_dead(proxy)

--- a/rotating_proxies/middlewares.py
+++ b/rotating_proxies/middlewares.py
@@ -168,8 +168,8 @@ class RotatingProxyMiddleware(object):
             self.stats.set_value('proxies/dead', len(self.proxies.dead))
             return self._retry(request, spider)
         elif ban is False:
-            self.stats.set_value('proxies/good', len(self.proxies.dead))
             self.proxies.mark_good(proxy)
+            self.stats.set_value('proxies/good', len(self.proxies.dead))
 
     def _retry(self, request, spider):
         retries = request.meta.get('proxy_retry_times', 0) + 1

--- a/rotating_proxies/middlewares.py
+++ b/rotating_proxies/middlewares.py
@@ -158,7 +158,7 @@ class RotatingProxyMiddleware(object):
         proxy = self.proxies.get_proxy(request.meta.get('proxy', None))
         if not (proxy and request.meta.get('_rotating_proxy')):
             return
-        self.stats.set_value('proxies/unchecked', len(self.proxies.unchecked))
+        self.stats.set_value('proxies/unchecked', len(self.proxies.unchecked) - len(self.proxies.reanimated))
         self.stats.set_value('proxies/reanimated', len(self.proxies.reanimated))
         self.stats.set_value('proxies/mean_backoff', self.proxies.mean_backoff_time)
         ban = request.meta.get('_ban', None)


### PR DESCRIPTION
This change introduce proxy stats updates to scrapy stats, e.g.:

     'proxies/dead': 3,
     'proxies/good': 10,
     'proxies/mean_backoff': 1815,
     'proxies/reanimated': 0,
     'proxies/unchecked': 4987,

This is great for standardizing stats to be more scrapy-like. This also allows easy access to stats for easier exporting to graph systems. 
