### PR TITLE
Always return float value for mean_backoff_time

### DIFF
--- a/rotating_proxies/expire.py
+++ b/rotating_proxies/expire.py
@@ -121,7 +121,7 @@ class Proxies(object):
     @property
     def mean_backoff_time(self):
         if not self.dead:
-            return 0
+            return 0.0
         total_backoff = sum(self.proxies[p].backoff_time for p in self.dead)
         return float(total_backoff) / len(self.dead)
 


### PR DESCRIPTION
Always return `mean_backoff_time` as a `float` number. Returning both `int` and `float` types can cause various problems, one example being field type conflict when storing stats values in databases like InfluxDB which have fixed schema. If `int` value comes first, there can't be written `float` value anytime after as the field already exists as an integer.