### PR TITLE
add BanAwareCachePolicy for http caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,10 @@ scrapy-rotating-proxies. To disable proxying for a request set
 ``request.meta['proxy'] = None``; to set proxy explicitly use
 ``request.meta['proxy'] = "<my-proxy-address>"``.
 
+To use scrapy's http cache with rotating proxies enable ban aware caching policy that prevents caching of banned responses:
+
+    HTTPCACHE_POLICY = 'rotating_proxies.policy.BanAwareCachePolicy'
+
 
 Concurrency
 -----------

--- a/rotating_proxies/policy.py
+++ b/rotating_proxies/policy.py
@@ -1,5 +1,19 @@
 # -*- coding: utf-8 -*-
 from scrapy.exceptions import IgnoreRequest
+from scrapy.extensions.httpcache import DummyPolicy
+
+
+class BanAwareCachePolicy(DummyPolicy):
+    """
+    This policy is for scrapy http caching that will prevent caching banned responses
+    Usage, in settings.py:
+        HTTPCACHE_POLICY = 'rotating_proxies.policy.BanAwareCachePolicy'
+    """
+
+    def should_cache_response(self, response, request):
+        if request.meta.get('_ban', False):
+            return False
+        return super().should_cache_response(response, request):
 
 
 class BanDetectionPolicy(object):


### PR DESCRIPTION
Add policy for scrapy's http caching that will refuse caching of banned responses as per https://github.com/TeamHG-Memex/scrapy-rotating-proxies/issues/20