### PR TITLE
Add dynamic signaling

### DIFF
--- a/tests/test_expire.py
+++ b/tests/test_expire.py
@@ -24,6 +24,18 @@ def test_proxies():
     p.mark_good('bar')
     assert p.get_random() == 'bar'
 
+    p.remove('foo')
+    assert p.get_random() == 'bar'
+
+    p.add('baz')
+    assert p.get_random() == 'bar'
+
+    p.remove('bar')
+    p.add('qux')
+    p.mark_good('qux')
+    assert p.get_random() == 'qux'
+
+
 
 def test_auth_proxies():
     proxy_list = ['http://foo:bar@baz:1234', 'http://egg:1234']


### PR DESCRIPTION
Adding and removing proxies is now possible through signals "ADD_PROXY" and "REMOVE_PROXY".

Additionally when a proxy is marked as dead/good a signal "DEAD_PROXY"/"GOOD_PROXY" is sent.

This enables the middleware to adapt proxies and dynamically spawn/kill proxies if the user wants.