### PR TITLE
Proxy-Authorization added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov
 docs/_build
 .hypothesis
 .html
+venv

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ Add ``ROTATING_PROXY_LIST`` option with a list of proxies to settings.py::
 
     ROTATING_PROXY_LIST = [
         'proxy1.com:8000',
-        'proxy2.com:8031',
+        'https://proxy2.com:8000',
+        'login:password@proxy3.com:8031',
+        'https://login:password@proxy4.com:8032',
         # ...
     ]
 

--- a/rotating_proxies/middlewares.py
+++ b/rotating_proxies/middlewares.py
@@ -2,8 +2,11 @@
 from __future__ import absolute_import
 import logging
 import codecs
+import re
+
 from functools import partial
 from six.moves.urllib.parse import urlsplit
+from w3lib.http import basic_auth_header
 
 from scrapy.exceptions import CloseSpider, NotConfigured
 from scrapy import signals
@@ -142,6 +145,11 @@ class RotatingProxyMiddleware(object):
                     logger.error("No proxies available even after a reset.")
                     raise CloseSpider("no_proxies_after_reset")
 
+        parts = re.match('(\w+://)([^:]+?:[^@]+?@)?(.+)', proxy)
+        if parts.group(2):
+            proxy = parts.group(3)
+            proxy_auth = basic_auth_header(*parts.group(2)[:-1].split(':'))
+            request.headers['Proxy-Authorization'] = proxy_auth
         request.meta['proxy'] = proxy
         request.meta['download_slot'] = self.get_proxy_slot(proxy)
         request.meta['_rotating_proxy'] = True

--- a/rotating_proxies/middlewares.py
+++ b/rotating_proxies/middlewares.py
@@ -2,8 +2,11 @@
 from __future__ import absolute_import
 import logging
 import codecs
-import re
 
+try:
+    from urllib2 import _parse_proxy
+except ImportError:
+    from urllib.request import _parse_proxy
 from functools import partial
 from six.moves.urllib.parse import urlsplit
 from w3lib.http import basic_auth_header
@@ -145,10 +148,9 @@ class RotatingProxyMiddleware(object):
                     logger.error("No proxies available even after a reset.")
                     raise CloseSpider("no_proxies_after_reset")
 
-        parts = re.match('(\w+://)([^:]+?:[^@]+?@)?(.+)', proxy)
-        if parts.group(2):
-            proxy = parts.group(3)
-            proxy_auth = basic_auth_header(*parts.group(2)[:-1].split(':'))
+        username, password = _parse_proxy(proxy)[1:3]
+        if username and password:
+            proxy_auth = basic_auth_header(username, password)
             request.headers['Proxy-Authorization'] = proxy_auth
         request.meta['proxy'] = proxy
         request.meta['download_slot'] = self.get_proxy_slot(proxy)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 import re
 import os
+import sys
 
 
 def get_version():
@@ -19,6 +20,15 @@ def get_long_description():
     ])
 
 
+# Do not install typing on python 3.7+
+INSTALL_REQUIRES = [
+    'attrs > 16.0.0',
+    'six',
+]
+if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] <= 6):
+    INSTALL_REQUIRES.append("typing")
+
+
 setup(
     name='scrapy-rotating-proxies',
     version=get_version(),
@@ -29,11 +39,7 @@ setup(
     description="Rotating proxies for Scrapy",
     url='https://github.com/TeamHG-Memex/scrapy-rotating-proxies',
     packages=find_packages(exclude=['tests']),
-    install_requires=[
-        'attrs > 16.0.0',
-        'six',
-        'typing',
-    ],
+    install_requires=INSTALL_REQUIRES,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
I think it's an important feature because not always people have an unauthorized proxy.

We had the following error before:
```
scrapy.core.downloader.handlers.http11.TunnelError: Could not open CONNECT tunnel with proxy <proxy> [{'status': 407, 'reason': b'Proxy Authentication Required'}]
```

Please, update PyPI after merging this request.